### PR TITLE
fix: point alias to `build/` instead of `src/`

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "rollup": "rollup -c rollup.config.mjs"
+    "rollup": "rollup -c rollup.config.mjs",
+    "clean": "rm -rf build/ *.tsbuildinfo"
   },
   "author": "",
   "license": "ISC",

--- a/packages/sdk/rollup.config.mjs
+++ b/packages/sdk/rollup.config.mjs
@@ -23,16 +23,17 @@ const config = {
     plugins: [
         nodeResolve(),
         typescript2({
-            // build: true,
             // useTsconfigDeclarationDir: true,
-            // declarationDir: './types',
+            // debugging options
+            verbosity: 3,
+            clean: true,
         }),
         // commonjs(),
     ],
     external: [
+        /@shared/,
         'undici',
         'querystring',
-
         'mobx',
         'mobx-react-lite',
         'mobx-utils',

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -28,7 +28,7 @@
     "declaration": true,
     "paths": {
       "@shared/*": [
-        "../../shared/src/*"
+        "../../shared/build/*"
       ]
     }
   },


### PR DESCRIPTION
## Summary

Fixes https://github.com/ezolenko/rollup-plugin-typescript2/issues/454

## Details

- this makes rpt2 have the same output as `tsc` for the `sdk` package
  - outputs to mirrored directory structure of `src`, w/ `actions/create.*` and `models/user.*` - implicit `rootDir` of `packages/sdk/src`, same as `tsc`

- mark `@shared` as an `external` in Rollup config
  - removes warning about it being treated as external

### Misc Changes

- add a `clean` command to help with debugging

- add `clean` and `verbosity` options to rpt2 to help with debugging / tracing
  - remove commented options that are not valid rpt2 options